### PR TITLE
fix: harden google api error handling

### DIFF
--- a/models/dataStruct/originalGoogleResponse/detailResponse.ts
+++ b/models/dataStruct/originalGoogleResponse/detailResponse.ts
@@ -4,6 +4,7 @@ export interface googleDetailResponse {
     html_attributions: string[];
     result: googleDetailItem;
     status: googleStatusEnum;
+    error_message?: string;
 }
 
 export interface googleDetailItem {

--- a/models/dataStruct/originalGoogleResponse/geocodeAutocompleteResponse.ts
+++ b/models/dataStruct/originalGoogleResponse/geocodeAutocompleteResponse.ts
@@ -4,6 +4,7 @@ export interface googleGeocodeAutocompleteResponse {
     plus_code?: plusCode;
     results: googleGeocodeAutocompleteResult[];
     status: googleStatusEnum;
+    error_message?: string;
 }
 
 export interface googleGeocodeAutocompleteResult {

--- a/models/dataStruct/originalGoogleResponse/placeResponse.ts
+++ b/models/dataStruct/originalGoogleResponse/placeResponse.ts
@@ -5,6 +5,7 @@ export interface googlePlaceResponse {
     next_page_token: string;
     results: googlePlaceResult[];
     status: googleStatusEnum;
+    error_message?: string;
 }
 
 export interface googlePlaceResult {

--- a/models/geocodeMgr.ts
+++ b/models/geocodeMgr.ts
@@ -31,7 +31,9 @@ async function autocomplete(location: latLngItem, input: string | undefined): Pr
     if (input) {
         let predictions: placeAutocompletePrediction[] = await getAutocompleteHistory(location, input, 1, undefined, 10);
         if (predictions.length === 0) {
-            let response: googleAutocompleteResponse = await callGoogleApiAutocomplete(input, location, undefined, 1);
+            // The previous 1m fallback radius was too small and caused valid nearby
+            // place keywords (for example "麥當") to return empty predictions.
+            let response: googleAutocompleteResponse = await callGoogleApiAutocomplete(input, location, undefined);
             updated = true;
             predictions = response.predictions;
         }
@@ -49,6 +51,13 @@ async function autocomplete(location: latLngItem, input: string | undefined): Pr
             let response: googleGeocodeAutocompleteResponse = await callGoogleApiGeocodeAddress(location);
             updated = true;
             historyResult = response.results;
+        }
+        if (historyResult.length === 0) {
+            return {
+                updated,
+                placeCount: 0,
+                placeList: []
+            };
         }
         let item = historyResult[0];
         outputList = [{
@@ -78,6 +87,9 @@ async function getLocationByAddress(address: string): Promise<getLocationByAddre
         let response: googleGeocodeAutocompleteResponse = await callGoogleApiGeocodeLocation(address);
         updated = true;
         historyResult = response.results;
+    }
+    if (historyResult.length === 0) {
+        throwError(errorCodes.placeNotFound, "查無符合地址");
     }
     let item = historyResult[0];
     let output: responseAutocompleteItem = {

--- a/models/service/googleApi/geocodeService.ts
+++ b/models/service/googleApi/geocodeService.ts
@@ -10,6 +10,16 @@ import {
     waypointByPlaceId
 } from "../../dataStruct/request/googleRoutesApiRequest";
 import {errorCodes, throwError} from "../../dataStruct/throwError";
+import {googleStatusEnum} from "../../dataStruct/originalGoogleResponse/pubilcItem";
+
+function assertGoogleStatus(status: googleStatusEnum, errorMessage?: string) {
+    if (status === googleStatusEnum.OK || status === googleStatusEnum.ZERO_RESULTS) return;
+
+    throwError(
+        errorCodes.unknown,
+        `Google Geocoding API 錯誤: ${status}${errorMessage ? ` - ${errorMessage}` : ""}`
+    );
+}
 
 // https://developers.google.com/maps/documentation/geocoding/start#reverse
 export async function callGoogleApiGeocodeAddress(location: latLngItem): Promise<googleGeocodeAutocompleteResponse> {
@@ -19,6 +29,7 @@ export async function callGoogleApiGeocodeAddress(location: latLngItem): Promise
         + `&key=${process.env.GOOGLE_API_KEY}`
         + `&language=zh-TW`;
     let response: googleGeocodeAutocompleteResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiGeocodeAutocompleteLog({location, response: response.results});
     return response;
 }
@@ -30,6 +41,7 @@ export async function callGoogleApiGeocodeLocation(address: string): Promise<goo
         + `&key=${process.env.GOOGLE_API_KEY}`
         + `&language=zh-TW`;
     let response: googleGeocodeAutocompleteResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiGeocodeAutocompleteLog({address, response: response.results});
     return response;
 }
@@ -52,7 +64,7 @@ export async function callGoogleApiComputeRoutes(origin: waypoint, destination: 
             origin: origin.place_id !== "" ? ({place_id: origin.place_id} as waypointByPlaceId) :
                 ({location: {latLng: {latitude: origin.lat, longitude: origin.lng}}} as waypointByLocation),
             destination: destination.place_id !== "" ? ({place_id: destination.place_id} as waypointByPlaceId) :
-                ({location: {latLng: {latitude: destination.lat, longitude: destination.lat}}} as waypointByLocation),
+                ({location: {latLng: {latitude: destination.lat, longitude: destination.lng}}} as waypointByLocation),
             travelMode: routeTravelModeEnum.WALK,
             computeAlternativeRoutes: false,
             routeModifiers: {avoidIndoor: false},
@@ -63,8 +75,10 @@ export async function callGoogleApiComputeRoutes(origin: waypoint, destination: 
     try {
         response = (await axios(config)).data;
     } catch (error: any) {
+        const googleErrorMessage = error?.response?.data?.error?.message;
+
         if (error.code === "ERR_BAD_REQUEST")
-            throwError(errorCodes.unknown, "API權限錯誤");
+            throwError(errorCodes.unknown, `Google Routes API 錯誤${googleErrorMessage ? `: ${googleErrorMessage}` : ""}`);
         throwError(errorCodes.unknown);
         throw Error();
     }

--- a/models/service/googleApi/placeService.ts
+++ b/models/service/googleApi/placeService.ts
@@ -8,6 +8,33 @@ import {
 import {googleAutocompleteResponse} from "../../dataStruct/originalGoogleResponse/autocompleteResponse";
 import {latLngItem} from "../../dataStruct/pubilcItem";
 import {googleDetailResponse} from "../../dataStruct/originalGoogleResponse/detailResponse";
+import {googleStatusEnum} from "../../dataStruct/originalGoogleResponse/pubilcItem";
+import {errorCodes, throwError} from "../../dataStruct/throwError";
+
+function assertGoogleStatus(status: googleStatusEnum, errorMessage?: string) {
+    if (status === googleStatusEnum.OK || status === googleStatusEnum.ZERO_RESULTS) return;
+
+    throwError(
+        errorCodes.unknown,
+        `Google Places API 錯誤: ${status}${errorMessage ? ` - ${errorMessage}` : ""}`
+    );
+}
+
+async function fetchPlacesPage(url: string, pageToken?: string): Promise<googlePlaceResponse> {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+
+        if (pageToken && response.status === googleStatusEnum.INVALID_REQUEST && attempt < 2) {
+            await new Promise((r) => setTimeout(r, 1000));
+            continue;
+        }
+
+        assertGoogleStatus(response.status, response.error_message);
+        return response;
+    }
+
+    throwError(errorCodes.unknown, 'Google Places API 錯誤: INVALID_REQUEST - next_page_token 尚未生效');
+}
 
 // https://developers.google.com/maps/documentation/places/web-service/search-nearby
 export async function callGoogleApiNearBySearch(searchPageNum: number, location: latLngItem, type: string, distance: number): Promise<googlePlaceResult[]> {
@@ -24,7 +51,7 @@ export async function callGoogleApiNearBySearch(searchPageNum: number, location:
             + `&type=${type}`
             + (distance <= 0 ? "&rankby=distance" : `&radius=${distance}`)
             + "&components=country:tw";
-        let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+        let response: googlePlaceResponse = await fetchPlacesPage(url, next_page_token || undefined);
         originalDataList = originalDataList.concat(response.results);
         next_page_token = response.next_page_token;
         console.log(`update ${type}: +${response.results.length}/${originalDataList.length}, next_page = ${next_page_token !== undefined}`)
@@ -45,7 +72,7 @@ export async function callGoogleApiKeywordBySearch(searchPageNum: number, locati
         + `&keyword=${keyword}`
         + (distance <= 0 ? "&rankby=distance" : `&radius=${distance}`)
         + "&components=country:tw";
-    let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+    let response: googlePlaceResponse = await fetchPlacesPage(url);
     let originalDataList: googlePlaceResult[] = response.results;
     let next_page_token: string | undefined = response.next_page_token;
     console.log(`update ${type}: +${response.results.length}/${originalDataList.length}, next_page = ${next_page_token !== undefined}`);
@@ -62,7 +89,7 @@ export async function callGoogleApiKeywordBySearch(searchPageNum: number, locati
                 + `&keyword=${keyword}`
                 + (distance === -1 ? "&rankby=distance" : `&radius=${distance}`)
                 + "&components=country:tw";
-            let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+            let response: googlePlaceResponse = await fetchPlacesPage(url, next_page_token);
             originalDataList = originalDataList.concat(response.results);
             next_page_token = response.next_page_token;
             console.log(`update ${type}: +${response.results.length}/${originalDataList.length}, next_page = ${next_page_token !== undefined}`)
@@ -82,6 +109,7 @@ export async function callGoogleApiDetail(place_id: string): Promise<googleDetai
         + `&place_id=${place_id}`
         + `&key=${process.env.GOOGLE_API_KEY}`;
     let response: googleDetailResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiDetailLog({place_id, response: response.result});
     return response;
 }
@@ -104,6 +132,7 @@ export async function callGoogleApiAutocomplete(input: string, location: latLngI
         + `&language=zh-TW`;
     if (type) url += `&type=${type}`;
     let response: googleAutocompleteResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiAutocompleteLog({
         input, type, distance, response: response.predictions, location
     });

--- a/tests/models/geocode-mgr.test.ts
+++ b/tests/models/geocode-mgr.test.ts
@@ -1,0 +1,63 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {errorCodes} from '../../models/dataStruct/throwError';
+import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
+
+vi.mock('../../models/service/placeService', () => ({
+  getAutocompleteHistory: vi.fn(),
+  getGeocodeAutocompleteHistory: vi.fn()
+}));
+
+vi.mock('../../models/service/geocodeService', () => ({
+  getGeocodeAutocompleteHistory: vi.fn()
+}));
+
+vi.mock('../../models/service/googleApi/geocodeService', () => ({
+  callGoogleApiGeocodeAddress: vi.fn(),
+  callGoogleApiGeocodeLocation: vi.fn(),
+  callGoogleApiComputeRoutes: vi.fn()
+}));
+
+vi.mock('../../models/service/googleApi/placeService', () => ({
+  callGoogleApiAutocomplete: vi.fn()
+}));
+
+import geocodeMgr from '../../models/geocodeMgr';
+import {getAutocompleteHistory} from '../../models/service/placeService';
+import {getGeocodeAutocompleteHistory} from '../../models/service/geocodeService';
+import {callGoogleApiGeocodeLocation} from '../../models/service/googleApi/geocodeService';
+import {callGoogleApiAutocomplete} from '../../models/service/googleApi/placeService';
+
+describe('geocodeMgr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the default Google autocomplete radius instead of forcing 1 meter', async () => {
+    vi.mocked(getAutocompleteHistory).mockResolvedValue([]);
+    vi.mocked(callGoogleApiAutocomplete).mockResolvedValue({
+      predictions: [],
+      status: googleStatusEnum.OK
+    });
+
+    await geocodeMgr.autocomplete({lat: 25.0516, lng: 121.5604}, '麥當');
+
+    expect(callGoogleApiAutocomplete).toHaveBeenCalledWith(
+      '麥當',
+      {lat: 25.0516, lng: 121.5604},
+      undefined
+    );
+  });
+
+  it('returns placeNotFound when geocode lookup has no matches', async () => {
+    vi.mocked(getGeocodeAutocompleteHistory).mockResolvedValue([]);
+    vi.mocked(callGoogleApiGeocodeLocation).mockResolvedValue({
+      results: [],
+      status: googleStatusEnum.ZERO_RESULTS
+    });
+
+    await expect(geocodeMgr.getLocationByAddress('not-found')).rejects.toMatchObject({
+      status: errorCodes.placeNotFound,
+      text: '查無符合地址'
+    });
+  });
+});

--- a/tests/services/google-api-geocode-service.test.ts
+++ b/tests/services/google-api-geocode-service.test.ts
@@ -1,0 +1,67 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import axios from 'axios';
+import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
+
+vi.mock('axios');
+vi.mock('../../models/service/googleApiLogService', () => ({
+  insertGoogleApiComputeRoutesLog: vi.fn(),
+  insertGoogleApiGeocodeAutocompleteLog: vi.fn()
+}));
+
+import {
+  callGoogleApiComputeRoutes,
+  callGoogleApiGeocodeLocation
+} from '../../models/service/googleApi/geocodeService';
+
+describe('google geocode service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces denied geocode responses with the Google status and message', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        results: [],
+        status: googleStatusEnum.REQUEST_DENIED,
+        error_message: 'API keys with referer restrictions cannot be used with this API.'
+      }
+    } as never);
+
+    await expect(callGoogleApiGeocodeLocation('台北101')).rejects.toMatchObject({
+      status: -1,
+      text: expect.stringContaining('Google Geocoding API 錯誤: REQUEST_DENIED')
+    });
+  });
+
+  it('builds routes requests with destination.lng instead of destination.lat', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        routes: [
+          {
+            distanceMeters: 123,
+            duration: '45s',
+            polyline: {encodedPolyline: 'abc'}
+          }
+        ]
+      }
+    } as never);
+
+    await callGoogleApiComputeRoutes(
+      {lat: 25.0516, lng: 121.5604, place_id: ''},
+      {lat: 25.0339, lng: 121.5644, place_id: ''}
+    );
+
+    expect(vi.mocked(axios)).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        destination: {
+          location: {
+            latLng: {
+              latitude: 25.0339,
+              longitude: 121.5644
+            }
+          }
+        }
+      })
+    }));
+  });
+});

--- a/tests/services/google-api-place-service.test.ts
+++ b/tests/services/google-api-place-service.test.ts
@@ -1,0 +1,63 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import axios from 'axios';
+import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
+
+vi.mock('axios');
+vi.mock('../../models/service/googleApiLogService', () => ({
+  insertGoogleApiAutocompleteLog: vi.fn(),
+  insertGoogleApiDetailLog: vi.fn(),
+  insertGoogleApiPlaceLog: vi.fn()
+}));
+
+import {callGoogleApiAutocomplete, callGoogleApiNearBySearch} from '../../models/service/googleApi/placeService';
+
+describe('google place service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces denied autocomplete responses with the Google status and message', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        predictions: [],
+        status: googleStatusEnum.REQUEST_DENIED,
+        error_message: 'This IP, site or mobile application is not authorized to use this API key.'
+      }
+    } as never);
+
+    await expect(callGoogleApiAutocomplete('麥當', {lat: 25.0516, lng: 121.5604}, undefined)).rejects.toMatchObject({
+      status: -1,
+      text: expect.stringContaining('Google Places API 錯誤: REQUEST_DENIED')
+    });
+  });
+
+  it('retries paginated nearby search responses when next_page_token is not ready yet', async () => {
+    vi.mocked(axios)
+      .mockResolvedValueOnce({
+        data: {
+          results: [{place_id: 'p1', geometry: {location: {lat: 25.05, lng: 121.56}, viewport: {northeast: {lat: 0, lng: 0}, southwest: {lat: 0, lng: 0}}}, icon: '', icon_background_color: '', icon_mask_base_uri: '', name: 'A', photos: [], plus_code: {compound_code: '', global_code: ''}, rating: 0, reference: '', scope: '', types: ['restaurant'], user_ratings_total: 0, vicinity: '', business_status: 'OPERATIONAL'}],
+          status: googleStatusEnum.OK,
+          next_page_token: 'next-token'
+        }
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          results: [],
+          status: googleStatusEnum.INVALID_REQUEST,
+          error_message: 'next_page_token is not ready'
+        }
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          results: [{place_id: 'p2', geometry: {location: {lat: 25.06, lng: 121.57}, viewport: {northeast: {lat: 0, lng: 0}, southwest: {lat: 0, lng: 0}}}, icon: '', icon_background_color: '', icon_mask_base_uri: '', name: 'B', photos: [], plus_code: {compound_code: '', global_code: ''}, rating: 0, reference: '', scope: '', types: ['restaurant'], user_ratings_total: 0, vicinity: '', business_status: 'OPERATIONAL'}],
+          status: googleStatusEnum.OK,
+          next_page_token: undefined
+        }
+      } as never);
+
+    const result = await callGoogleApiNearBySearch(2, {lat: 25.0516, lng: 121.5604}, 'restaurant', -1);
+
+    expect(result).toHaveLength(2);
+    expect(vi.mocked(axios)).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## 問題
- `/api/geocode/autocomplete` 在 Google 回錯誤時會被吃掉，外部只看到 `placeList: []`，不容易判斷實際是 Google API 權限/設定問題。
- `geocode autocomplete` fallback 呼叫 Google Places Autocomplete 時把 radius 硬編成 `1`，會讓像「麥當」這類本來應該有結果的查詢直接變成空結果。
- `/api/geocode/get_location_by_address` 在 Google 沒回結果時會往下取 `historyResult[0]`，最後變成泛用的「未知錯誤」。
- `computeRoutes` 組 request body 時把 destination 的 `longitude` 寫成 `destination.lat`，導致路線請求座標錯誤。
- Google Places 的分頁 `next_page_token` 尚未生效時會短暫回 `INVALID_REQUEST`；需要重試，不能直接視為永久錯誤。

## 修正內容
- 在 Google Places / Geocoding / Routes 呼叫補上狀態檢查，將 Google 的 `status` 與 `error_message` 明確往上帶，避免錯誤被吞掉。
- 修正 geocode autocomplete fallback，不再強制使用 1 公尺半徑，改用原本的 Places Autocomplete 預設範圍。
- 補上 geocode 查無資料時的保護，避免空陣列索引，改為回傳合理結果或明確錯誤。
- 修正 Routes API request 中 destination 經度欄位，改為使用 `destination.lng`。
- 針對 Places 分頁查詢加入 `INVALID_REQUEST` retry，避免 `next_page_token` 尚未 ready 時誤判失敗。
- 為 Google 回應型別補上 `error_message` 欄位，方便統一處理 API 錯誤。

## 驗證
- 新增測試：
  - `tests/models/geocode-mgr.test.ts`
  - `tests/services/google-api-geocode-service.test.ts`
  - `tests/services/google-api-place-service.test.ts`
- 執行 `corepack pnpm test` 通過（30 tests）
