### PR TITLE
ci: keep verify on arc runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: 'kkldream-food-map-server'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## 問題
- 前一個 PR 合併後，我後續補上的 workflow runner 調整 commit（`c6b2b5f`）沒有進到新的 PR。
- 使用者要求 verify / deploy 都統一使用自架的 `kkldream-food-map-server` runner。
- 目前 `fix/google-api-error-handling-and-routes` 相對 `dev` 只剩這一個 workflow commit 尚未合併。

## 修正內容
- 將 verify job 的 runner 從 `ubuntu-latest` 改回 `kkldream-food-map-server`。
- 保留先前已修好的 workflow 結構：
  - `pull_request` 只跑 verify
  - deploy 只在非 PR 且 branch 為 `main` / `dev` 時執行

## 驗證
- 手動觸發 workflow_dispatch run `24550109317`
- 結果：verify 成功、deploy 正確不執行
