### PR TITLE
將 dev 合併到 main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build and Deploy to K8s
 on:
   push:
     branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
   workflow_dispatch:
 
 env:
@@ -11,9 +13,8 @@ env:
   K8S_NAMESPACE: apps
 
 jobs:
-  build-and-deploy:
-    runs-on: 'kkldream-food-map-server'
-    environment: 'main'
+  verify:
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -36,21 +37,38 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Run TypeScript build
+        run: pnpm build
+
+  deploy:
+    runs-on: 'kkldream-food-map-server'
+    needs: verify
+    if: github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'dev')
+    environment: 'main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set deploy context
         run: |
-          BRANCH="${{ github.ref_name }}"
+          set -euo pipefail
+
+          REF_NAME="${{ github.ref_name }}"
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          IMAGE_TAG="${BRANCH}-${SHORT_SHA}"
+          REF_SLUG=$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]+#-#g; s#-+#-#g; s#(^[-.]+|[-.]+$)##g')
+          IMAGE_TAG="${REF_SLUG}-${SHORT_SHA}"
+          IMAGE_REF="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+          DEPLOY_BRANCH="$REF_NAME"
 
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_ENV"
+          echo "DEPLOY_BRANCH=${DEPLOY_BRANCH}" >> "$GITHUB_ENV"
+          echo "SECRET_NAME=food-map-secrets-${DEPLOY_BRANCH}" >> "$GITHUB_ENV"
+          echo "KUSTOMIZE_DIR=k8s/overlays/${DEPLOY_BRANCH}" >> "$GITHUB_ENV"
+          echo "RESOURCE_NAME=food-map-server-${DEPLOY_BRANCH}" >> "$GITHUB_ENV"
 
-          echo "SECRET_NAME=food-map-secrets-${BRANCH}" >> $GITHUB_ENV
-          echo "KUSTOMIZE_DIR=k8s/overlays/${BRANCH}" >> $GITHUB_ENV
-          echo "RESOURCE_NAME=food-map-server-${BRANCH}" >> $GITHUB_ENV
-          echo "IMAGE_REF=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
-
-          echo "Deploy context: branch=${BRANCH} image_tag=${IMAGE_TAG} image_ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "Deploy context: branch=${DEPLOY_BRANCH} image_tag=${IMAGE_TAG} image_ref=${IMAGE_REF}"
 
       - name: Build Docker image
         run: |
@@ -66,26 +84,26 @@ jobs:
 
       - name: Create or update secrets
         run: |
-          kubectl create secret generic ${{ env.SECRET_NAME }} \
-            --namespace=${{ env.K8S_NAMESPACE }} \
-            --from-literal=ROOT_ACCESS_KEY=${{ secrets.ROOT_ACCESS_KEY }} \
-            --from-literal=MONGODB_URL=${{ secrets.MONGODB_URL }} \
-            --from-literal=GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }} \
-            --from-literal=FCM_ACCESS_KEY=${{ secrets.FCM_ACCESS_KEY }} \
-            --from-literal=SESSION_SECRET=${{ secrets.SESSION_SECRET }} \
+          kubectl create secret generic "${SECRET_NAME}" \
+            --namespace="${{ env.K8S_NAMESPACE }}" \
+            --from-literal=ROOT_ACCESS_KEY="${{ secrets.ROOT_ACCESS_KEY }}" \
+            --from-literal=MONGODB_URL="${{ secrets.MONGODB_URL }}" \
+            --from-literal=GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}" \
+            --from-literal=FCM_ACCESS_KEY="${{ secrets.FCM_ACCESS_KEY }}" \
+            --from-literal=SESSION_SECRET="${{ secrets.SESSION_SECRET }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy to Kubernetes
         run: |
-          sed -i "s|newTag: .*|newTag: ${{ env.IMAGE_TAG }}|g" ${{ env.KUSTOMIZE_DIR }}/kustomization.yaml
-          kubectl apply -k ${{ env.KUSTOMIZE_DIR }}
+          sed -i "s|newTag: .*|newTag: ${IMAGE_TAG}|g" "${KUSTOMIZE_DIR}/kustomization.yaml"
+          kubectl apply -k "${KUSTOMIZE_DIR}"
 
       - name: Verify deployment
         run: |
-          kubectl rollout status deployment/${{ env.RESOURCE_NAME }} \
-            -n ${{ env.K8S_NAMESPACE }} \
+          kubectl rollout status "deployment/${RESOURCE_NAME}" \
+            -n "${{ env.K8S_NAMESPACE }}" \
             --timeout=120s
           echo "========== Pods =========="
-          kubectl get pods -n ${{ env.K8S_NAMESPACE }} -l app=${{ env.RESOURCE_NAME }}
+          kubectl get pods -n "${{ env.K8S_NAMESPACE }}" -l "app=${RESOURCE_NAME}"
           echo "========== Service =========="
-          kubectl get svc ${{ env.RESOURCE_NAME }} -n ${{ env.K8S_NAMESPACE }}
+          kubectl get svc "${RESOURCE_NAME}" -n "${{ env.K8S_NAMESPACE }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: 'kkldream-food-map-server'
 
     steps:
       - name: Checkout code

--- a/models/dataStruct/originalGoogleResponse/detailResponse.ts
+++ b/models/dataStruct/originalGoogleResponse/detailResponse.ts
@@ -4,6 +4,7 @@ export interface googleDetailResponse {
     html_attributions: string[];
     result: googleDetailItem;
     status: googleStatusEnum;
+    error_message?: string;
 }
 
 export interface googleDetailItem {

--- a/models/dataStruct/originalGoogleResponse/geocodeAutocompleteResponse.ts
+++ b/models/dataStruct/originalGoogleResponse/geocodeAutocompleteResponse.ts
@@ -4,6 +4,7 @@ export interface googleGeocodeAutocompleteResponse {
     plus_code?: plusCode;
     results: googleGeocodeAutocompleteResult[];
     status: googleStatusEnum;
+    error_message?: string;
 }
 
 export interface googleGeocodeAutocompleteResult {

--- a/models/dataStruct/originalGoogleResponse/placeResponse.ts
+++ b/models/dataStruct/originalGoogleResponse/placeResponse.ts
@@ -5,6 +5,7 @@ export interface googlePlaceResponse {
     next_page_token: string;
     results: googlePlaceResult[];
     status: googleStatusEnum;
+    error_message?: string;
 }
 
 export interface googlePlaceResult {

--- a/models/dataStruct/throwError.ts
+++ b/models/dataStruct/throwError.ts
@@ -15,7 +15,7 @@ export enum errorCodes {
     photoUrlError = 10,
 }
 
-export function throwError(errorCode: errorCodes, msg: string = ''): apiError {
+export function throwError(errorCode: errorCodes, msg: string = ''): never {
     let status = errorCode ?? errorCodes.unknown;
     if (msg === '')
         switch (errorCode) {

--- a/models/geocodeMgr.ts
+++ b/models/geocodeMgr.ts
@@ -31,7 +31,9 @@ async function autocomplete(location: latLngItem, input: string | undefined): Pr
     if (input) {
         let predictions: placeAutocompletePrediction[] = await getAutocompleteHistory(location, input, 1, undefined, 10);
         if (predictions.length === 0) {
-            let response: googleAutocompleteResponse = await callGoogleApiAutocomplete(input, location, undefined, 1);
+            // The previous 1m fallback radius was too small and caused valid nearby
+            // place keywords (for example "麥當") to return empty predictions.
+            let response: googleAutocompleteResponse = await callGoogleApiAutocomplete(input, location, undefined);
             updated = true;
             predictions = response.predictions;
         }
@@ -49,6 +51,13 @@ async function autocomplete(location: latLngItem, input: string | undefined): Pr
             let response: googleGeocodeAutocompleteResponse = await callGoogleApiGeocodeAddress(location);
             updated = true;
             historyResult = response.results;
+        }
+        if (historyResult.length === 0) {
+            return {
+                updated,
+                placeCount: 0,
+                placeList: []
+            };
         }
         let item = historyResult[0];
         outputList = [{
@@ -78,6 +87,9 @@ async function getLocationByAddress(address: string): Promise<getLocationByAddre
         let response: googleGeocodeAutocompleteResponse = await callGoogleApiGeocodeLocation(address);
         updated = true;
         historyResult = response.results;
+    }
+    if (historyResult.length === 0) {
+        throwError(errorCodes.placeNotFound, "查無符合地址");
     }
     let item = historyResult[0];
     let output: responseAutocompleteItem = {

--- a/models/service/googleApi/geocodeService.ts
+++ b/models/service/googleApi/geocodeService.ts
@@ -10,6 +10,16 @@ import {
     waypointByPlaceId
 } from "../../dataStruct/request/googleRoutesApiRequest";
 import {errorCodes, throwError} from "../../dataStruct/throwError";
+import {googleStatusEnum} from "../../dataStruct/originalGoogleResponse/pubilcItem";
+
+function assertGoogleStatus(status: googleStatusEnum, errorMessage?: string) {
+    if (status === googleStatusEnum.OK || status === googleStatusEnum.ZERO_RESULTS) return;
+
+    throwError(
+        errorCodes.unknown,
+        `Google Geocoding API 錯誤: ${status}${errorMessage ? ` - ${errorMessage}` : ""}`
+    );
+}
 
 // https://developers.google.com/maps/documentation/geocoding/start#reverse
 export async function callGoogleApiGeocodeAddress(location: latLngItem): Promise<googleGeocodeAutocompleteResponse> {
@@ -19,6 +29,7 @@ export async function callGoogleApiGeocodeAddress(location: latLngItem): Promise
         + `&key=${process.env.GOOGLE_API_KEY}`
         + `&language=zh-TW`;
     let response: googleGeocodeAutocompleteResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiGeocodeAutocompleteLog({location, response: response.results});
     return response;
 }
@@ -30,6 +41,7 @@ export async function callGoogleApiGeocodeLocation(address: string): Promise<goo
         + `&key=${process.env.GOOGLE_API_KEY}`
         + `&language=zh-TW`;
     let response: googleGeocodeAutocompleteResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiGeocodeAutocompleteLog({address, response: response.results});
     return response;
 }
@@ -52,7 +64,7 @@ export async function callGoogleApiComputeRoutes(origin: waypoint, destination: 
             origin: origin.place_id !== "" ? ({place_id: origin.place_id} as waypointByPlaceId) :
                 ({location: {latLng: {latitude: origin.lat, longitude: origin.lng}}} as waypointByLocation),
             destination: destination.place_id !== "" ? ({place_id: destination.place_id} as waypointByPlaceId) :
-                ({location: {latLng: {latitude: destination.lat, longitude: destination.lat}}} as waypointByLocation),
+                ({location: {latLng: {latitude: destination.lat, longitude: destination.lng}}} as waypointByLocation),
             travelMode: routeTravelModeEnum.WALK,
             computeAlternativeRoutes: false,
             routeModifiers: {avoidIndoor: false},
@@ -63,8 +75,10 @@ export async function callGoogleApiComputeRoutes(origin: waypoint, destination: 
     try {
         response = (await axios(config)).data;
     } catch (error: any) {
+        const googleErrorMessage = error?.response?.data?.error?.message;
+
         if (error.code === "ERR_BAD_REQUEST")
-            throwError(errorCodes.unknown, "API權限錯誤");
+            throwError(errorCodes.unknown, `Google Routes API 錯誤${googleErrorMessage ? `: ${googleErrorMessage}` : ""}`);
         throwError(errorCodes.unknown);
         throw Error();
     }

--- a/models/service/googleApi/placeService.ts
+++ b/models/service/googleApi/placeService.ts
@@ -8,6 +8,33 @@ import {
 import {googleAutocompleteResponse} from "../../dataStruct/originalGoogleResponse/autocompleteResponse";
 import {latLngItem} from "../../dataStruct/pubilcItem";
 import {googleDetailResponse} from "../../dataStruct/originalGoogleResponse/detailResponse";
+import {googleStatusEnum} from "../../dataStruct/originalGoogleResponse/pubilcItem";
+import {errorCodes, throwError} from "../../dataStruct/throwError";
+
+function assertGoogleStatus(status: googleStatusEnum, errorMessage?: string) {
+    if (status === googleStatusEnum.OK || status === googleStatusEnum.ZERO_RESULTS) return;
+
+    throwError(
+        errorCodes.unknown,
+        `Google Places API 錯誤: ${status}${errorMessage ? ` - ${errorMessage}` : ""}`
+    );
+}
+
+async function fetchPlacesPage(url: string, pageToken?: string): Promise<googlePlaceResponse> {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+
+        if (pageToken && response.status === googleStatusEnum.INVALID_REQUEST && attempt < 2) {
+            await new Promise((r) => setTimeout(r, 1000));
+            continue;
+        }
+
+        assertGoogleStatus(response.status, response.error_message);
+        return response;
+    }
+
+    throwError(errorCodes.unknown, 'Google Places API 錯誤: INVALID_REQUEST - next_page_token 尚未生效');
+}
 
 // https://developers.google.com/maps/documentation/places/web-service/search-nearby
 export async function callGoogleApiNearBySearch(searchPageNum: number, location: latLngItem, type: string, distance: number): Promise<googlePlaceResult[]> {
@@ -24,7 +51,7 @@ export async function callGoogleApiNearBySearch(searchPageNum: number, location:
             + `&type=${type}`
             + (distance <= 0 ? "&rankby=distance" : `&radius=${distance}`)
             + "&components=country:tw";
-        let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+        let response: googlePlaceResponse = await fetchPlacesPage(url, next_page_token || undefined);
         originalDataList = originalDataList.concat(response.results);
         next_page_token = response.next_page_token;
         console.log(`update ${type}: +${response.results.length}/${originalDataList.length}, next_page = ${next_page_token !== undefined}`)
@@ -45,7 +72,7 @@ export async function callGoogleApiKeywordBySearch(searchPageNum: number, locati
         + `&keyword=${keyword}`
         + (distance <= 0 ? "&rankby=distance" : `&radius=${distance}`)
         + "&components=country:tw";
-    let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+    let response: googlePlaceResponse = await fetchPlacesPage(url);
     let originalDataList: googlePlaceResult[] = response.results;
     let next_page_token: string | undefined = response.next_page_token;
     console.log(`update ${type}: +${response.results.length}/${originalDataList.length}, next_page = ${next_page_token !== undefined}`);
@@ -62,7 +89,7 @@ export async function callGoogleApiKeywordBySearch(searchPageNum: number, locati
                 + `&keyword=${keyword}`
                 + (distance === -1 ? "&rankby=distance" : `&radius=${distance}`)
                 + "&components=country:tw";
-            let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
+            let response: googlePlaceResponse = await fetchPlacesPage(url, next_page_token);
             originalDataList = originalDataList.concat(response.results);
             next_page_token = response.next_page_token;
             console.log(`update ${type}: +${response.results.length}/${originalDataList.length}, next_page = ${next_page_token !== undefined}`)
@@ -82,6 +109,7 @@ export async function callGoogleApiDetail(place_id: string): Promise<googleDetai
         + `&place_id=${place_id}`
         + `&key=${process.env.GOOGLE_API_KEY}`;
     let response: googleDetailResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiDetailLog({place_id, response: response.result});
     return response;
 }
@@ -104,6 +132,7 @@ export async function callGoogleApiAutocomplete(input: string, location: latLngI
         + `&language=zh-TW`;
     if (type) url += `&type=${type}`;
     let response: googleAutocompleteResponse = (await axios({method: 'get', url})).data;
+    assertGoogleStatus(response.status, response.error_message);
     await insertGoogleApiAutocompleteLog({
         input, type, distance, response: response.predictions, location
     });

--- a/tests/models/geocode-mgr.test.ts
+++ b/tests/models/geocode-mgr.test.ts
@@ -1,0 +1,63 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {errorCodes} from '../../models/dataStruct/throwError';
+import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
+
+vi.mock('../../models/service/placeService', () => ({
+  getAutocompleteHistory: vi.fn(),
+  getGeocodeAutocompleteHistory: vi.fn()
+}));
+
+vi.mock('../../models/service/geocodeService', () => ({
+  getGeocodeAutocompleteHistory: vi.fn()
+}));
+
+vi.mock('../../models/service/googleApi/geocodeService', () => ({
+  callGoogleApiGeocodeAddress: vi.fn(),
+  callGoogleApiGeocodeLocation: vi.fn(),
+  callGoogleApiComputeRoutes: vi.fn()
+}));
+
+vi.mock('../../models/service/googleApi/placeService', () => ({
+  callGoogleApiAutocomplete: vi.fn()
+}));
+
+import geocodeMgr from '../../models/geocodeMgr';
+import {getAutocompleteHistory} from '../../models/service/placeService';
+import {getGeocodeAutocompleteHistory} from '../../models/service/geocodeService';
+import {callGoogleApiGeocodeLocation} from '../../models/service/googleApi/geocodeService';
+import {callGoogleApiAutocomplete} from '../../models/service/googleApi/placeService';
+
+describe('geocodeMgr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the default Google autocomplete radius instead of forcing 1 meter', async () => {
+    vi.mocked(getAutocompleteHistory).mockResolvedValue([]);
+    vi.mocked(callGoogleApiAutocomplete).mockResolvedValue({
+      predictions: [],
+      status: googleStatusEnum.OK
+    });
+
+    await geocodeMgr.autocomplete({lat: 25.0516, lng: 121.5604}, '麥當');
+
+    expect(callGoogleApiAutocomplete).toHaveBeenCalledWith(
+      '麥當',
+      {lat: 25.0516, lng: 121.5604},
+      undefined
+    );
+  });
+
+  it('returns placeNotFound when geocode lookup has no matches', async () => {
+    vi.mocked(getGeocodeAutocompleteHistory).mockResolvedValue([]);
+    vi.mocked(callGoogleApiGeocodeLocation).mockResolvedValue({
+      results: [],
+      status: googleStatusEnum.ZERO_RESULTS
+    });
+
+    await expect(geocodeMgr.getLocationByAddress('not-found')).rejects.toMatchObject({
+      status: errorCodes.placeNotFound,
+      text: '查無符合地址'
+    });
+  });
+});

--- a/tests/services/google-api-geocode-service.test.ts
+++ b/tests/services/google-api-geocode-service.test.ts
@@ -1,0 +1,67 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import axios from 'axios';
+import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
+
+vi.mock('axios');
+vi.mock('../../models/service/googleApiLogService', () => ({
+  insertGoogleApiComputeRoutesLog: vi.fn(),
+  insertGoogleApiGeocodeAutocompleteLog: vi.fn()
+}));
+
+import {
+  callGoogleApiComputeRoutes,
+  callGoogleApiGeocodeLocation
+} from '../../models/service/googleApi/geocodeService';
+
+describe('google geocode service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces denied geocode responses with the Google status and message', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        results: [],
+        status: googleStatusEnum.REQUEST_DENIED,
+        error_message: 'API keys with referer restrictions cannot be used with this API.'
+      }
+    } as never);
+
+    await expect(callGoogleApiGeocodeLocation('台北101')).rejects.toMatchObject({
+      status: -1,
+      text: expect.stringContaining('Google Geocoding API 錯誤: REQUEST_DENIED')
+    });
+  });
+
+  it('builds routes requests with destination.lng instead of destination.lat', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        routes: [
+          {
+            distanceMeters: 123,
+            duration: '45s',
+            polyline: {encodedPolyline: 'abc'}
+          }
+        ]
+      }
+    } as never);
+
+    await callGoogleApiComputeRoutes(
+      {lat: 25.0516, lng: 121.5604, place_id: ''},
+      {lat: 25.0339, lng: 121.5644, place_id: ''}
+    );
+
+    expect(vi.mocked(axios)).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        destination: {
+          location: {
+            latLng: {
+              latitude: 25.0339,
+              longitude: 121.5644
+            }
+          }
+        }
+      })
+    }));
+  });
+});

--- a/tests/services/google-api-place-service.test.ts
+++ b/tests/services/google-api-place-service.test.ts
@@ -1,0 +1,63 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import axios from 'axios';
+import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
+
+vi.mock('axios');
+vi.mock('../../models/service/googleApiLogService', () => ({
+  insertGoogleApiAutocompleteLog: vi.fn(),
+  insertGoogleApiDetailLog: vi.fn(),
+  insertGoogleApiPlaceLog: vi.fn()
+}));
+
+import {callGoogleApiAutocomplete, callGoogleApiNearBySearch} from '../../models/service/googleApi/placeService';
+
+describe('google place service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces denied autocomplete responses with the Google status and message', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        predictions: [],
+        status: googleStatusEnum.REQUEST_DENIED,
+        error_message: 'This IP, site or mobile application is not authorized to use this API key.'
+      }
+    } as never);
+
+    await expect(callGoogleApiAutocomplete('麥當', {lat: 25.0516, lng: 121.5604}, undefined)).rejects.toMatchObject({
+      status: -1,
+      text: expect.stringContaining('Google Places API 錯誤: REQUEST_DENIED')
+    });
+  });
+
+  it('retries paginated nearby search responses when next_page_token is not ready yet', async () => {
+    vi.mocked(axios)
+      .mockResolvedValueOnce({
+        data: {
+          results: [{place_id: 'p1', geometry: {location: {lat: 25.05, lng: 121.56}, viewport: {northeast: {lat: 0, lng: 0}, southwest: {lat: 0, lng: 0}}}, icon: '', icon_background_color: '', icon_mask_base_uri: '', name: 'A', photos: [], plus_code: {compound_code: '', global_code: ''}, rating: 0, reference: '', scope: '', types: ['restaurant'], user_ratings_total: 0, vicinity: '', business_status: 'OPERATIONAL'}],
+          status: googleStatusEnum.OK,
+          next_page_token: 'next-token'
+        }
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          results: [],
+          status: googleStatusEnum.INVALID_REQUEST,
+          error_message: 'next_page_token is not ready'
+        }
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          results: [{place_id: 'p2', geometry: {location: {lat: 25.06, lng: 121.57}, viewport: {northeast: {lat: 0, lng: 0}, southwest: {lat: 0, lng: 0}}}, icon: '', icon_background_color: '', icon_mask_base_uri: '', name: 'B', photos: [], plus_code: {compound_code: '', global_code: ''}, rating: 0, reference: '', scope: '', types: ['restaurant'], user_ratings_total: 0, vicinity: '', business_status: 'OPERATIONAL'}],
+          status: googleStatusEnum.OK,
+          next_page_token: undefined
+        }
+      } as never);
+
+    const result = await callGoogleApiNearBySearch(2, {lat: 25.0516, lng: 121.5604}, 'restaurant', -1);
+
+    expect(result).toHaveLength(2);
+    expect(vi.mocked(axios)).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## 摘要
- 將最新 `dev` 變更合併到 `main`
- 包含 Google API 錯誤處理修正
- 包含 CI workflow 的 verify / deploy 分流調整，以及 ARC runner 使用方式修正

## 本次包含的重點
- Google API 發生錯誤時，會正確帶出 `status` / `error_message`，不再默默吞掉失敗
- 修正 geocode autocomplete fallback 的行為
- 修正 routes destination 經度使用錯誤
- 透過 `throwError(): never` 修正 TypeScript build 卡住的問題
- 調整 deploy workflow：PR 只跑 verify；deploy 僅限 `main` / `dev` 觸發
- verify workflow 改為使用自架 ARC runner `kkldream-food-map-server`

## 驗證
- `dev` 分支上的 PR verify workflow 已通過