### PR TITLE
fix: 修正 place autocomplete 的 Google API 參數與錯誤處理

### DIFF
--- a/models/service/googleApi/placeService.ts
+++ b/models/service/googleApi/placeService.ts
@@ -20,6 +20,18 @@ function assertGoogleStatus(status: googleStatusEnum, errorMessage?: string) {
     );
 }
 
+function handleGoogleAxiosError(error: unknown): never {
+    if (axios.isAxiosError(error)) {
+        const googleResponse = error.response?.data as {status?: googleStatusEnum; error_message?: string} | undefined;
+        if (googleResponse?.status) {
+            assertGoogleStatus(googleResponse.status, googleResponse.error_message);
+        }
+        throwError(errorCodes.unknown, error.message);
+    }
+
+    throw error;
+}
+
 async function fetchPlacesPage(url: string, pageToken?: string): Promise<googlePlaceResponse> {
     for (let attempt = 0; attempt < 3; attempt++) {
         let response: googlePlaceResponse = (await axios({method: 'get', url})).data;
@@ -123,18 +135,26 @@ export async function callGoogleApiDetail(place_id: string): Promise<googleDetai
  * @param distance 單位公尺，預設為30000，範圍大於等於1
  */
 export async function callGoogleApiAutocomplete(input: string, location: latLngItem, type: string | undefined, distance: number = 30000): Promise<googleAutocompleteResponse> {
-    let url = 'https://maps.googleapis.com/maps/api/place/autocomplete/json?'
-        + `&input=${input}`
-        + `&location=${location.lat},${location.lng}`
-        + `&components=country:tw`
-        + `&radius=${distance}`
-        + `&key=${process.env.GOOGLE_API_KEY}`
-        + `&language=zh-TW`;
-    if (type) url += `&type=${type}`;
-    let response: googleAutocompleteResponse = (await axios({method: 'get', url})).data;
-    assertGoogleStatus(response.status, response.error_message);
-    await insertGoogleApiAutocompleteLog({
-        input, type, distance, response: response.predictions, location
-    });
-    return response;
+    try {
+        const response: googleAutocompleteResponse = (await axios({
+            method: 'get',
+            url: 'https://maps.googleapis.com/maps/api/place/autocomplete/json',
+            params: {
+                input,
+                location: `${location.lat},${location.lng}`,
+                components: 'country:tw',
+                radius: distance,
+                key: process.env.GOOGLE_API_KEY,
+                language: 'zh-TW',
+                ...(type ? {types: type} : {})
+            }
+        })).data;
+        assertGoogleStatus(response.status, response.error_message);
+        await insertGoogleApiAutocompleteLog({
+            input, type, distance, response: response.predictions, location
+        });
+        return response;
+    } catch (error) {
+        handleGoogleAxiosError(error);
+    }
 }

--- a/tests/services/google-api-place-service.test.ts
+++ b/tests/services/google-api-place-service.test.ts
@@ -2,7 +2,14 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 import axios from 'axios';
 import {googleStatusEnum} from '../../models/dataStruct/originalGoogleResponse/pubilcItem';
 
-vi.mock('axios');
+vi.mock('axios', () => {
+  const axiosMock = vi.fn();
+  return {
+    default: Object.assign(axiosMock, {
+      isAxiosError: vi.fn()
+    })
+  };
+});
 vi.mock('../../models/service/googleApiLogService', () => ({
   insertGoogleApiAutocompleteLog: vi.fn(),
   insertGoogleApiDetailLog: vi.fn(),
@@ -14,6 +21,7 @@ import {callGoogleApiAutocomplete, callGoogleApiNearBySearch} from '../../models
 describe('google place service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(axios.isAxiosError).mockImplementation((error: unknown) => Boolean((error as {isAxiosError?: boolean})?.isAxiosError));
   });
 
   it('surfaces denied autocomplete responses with the Google status and message', async () => {
@@ -28,6 +36,48 @@ describe('google place service', () => {
     await expect(callGoogleApiAutocomplete('麥當', {lat: 25.0516, lng: 121.5604}, undefined)).rejects.toMatchObject({
       status: -1,
       text: expect.stringContaining('Google Places API 錯誤: REQUEST_DENIED')
+    });
+  });
+
+  it('uses the legacy autocomplete types parameter when filtering place types', async () => {
+    vi.mocked(axios).mockResolvedValue({
+      data: {
+        predictions: [],
+        status: googleStatusEnum.OK
+      }
+    } as never);
+
+    await callGoogleApiAutocomplete('麥當', {lat: 25.0516, lng: 121.5604}, 'restaurant', 100);
+
+    expect(vi.mocked(axios)).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'get',
+      url: 'https://maps.googleapis.com/maps/api/place/autocomplete/json',
+      params: expect.objectContaining({
+        input: '麥當',
+        location: '25.0516,121.5604',
+        radius: 100,
+        language: 'zh-TW',
+        components: 'country:tw',
+        types: 'restaurant'
+      })
+    }));
+  });
+
+  it('converts Google HTTP errors into api errors instead of leaking a generic AxiosError', async () => {
+    vi.mocked(axios).mockRejectedValue({
+      isAxiosError: true,
+      message: 'Request failed with status code 400',
+      response: {
+        data: {
+          status: googleStatusEnum.INVALID_REQUEST,
+          error_message: 'Invalid types parameter.'
+        }
+      }
+    } as never);
+
+    await expect(callGoogleApiAutocomplete('麥當', {lat: 25.0516, lng: 121.5604}, 'restaurant', 100)).rejects.toMatchObject({
+      status: -1,
+      text: expect.stringContaining('Google Places API 錯誤: INVALID_REQUEST - Invalid types parameter.')
     });
   });
 


### PR DESCRIPTION
## 問題說明
- `/api/place/autocomplete` 目前在特定查詢（例如 `麥當`、`distance=100`）會回傳 `{"status":-1,"errMsg":"未知錯誤"}`。
- 追查後確認，place autocomplete 送給 Google Places Autocomplete (Legacy) 的參數名稱寫成 `type`，但該 API 實際需要的是 `types`。
- 由於 Google 在這種情況下會以 HTTP 錯誤回應，程式原本沒有把 Axios/Google 錯誤轉成專案既有的 `apiError`，最後只會被包成泛用的「未知錯誤」。

## 這次修正
- 修正 place autocomplete 對 Google 的請求參數：`type` -> `types`。
- 改用 `params` 組裝 autocomplete request，避免 query string 手動拼接再出錯。
- 補上 Axios 錯誤轉譯，若 Google 直接回 HTTP 錯誤，會盡量帶出 `status` / `error_message`，不再只剩「未知錯誤」。
- 新增回歸測試，覆蓋：
  - autocomplete 會正確送出 `types=restaurant`
  - Google HTTP 錯誤會被轉成專案內的 `apiError`

## 排查結果
- 這次實際重現到的壞點是 `/api/place/autocomplete`。
- 其他 Google API 服務在目前測試下沒有新增失敗案例；本次 PR 先聚焦修正已重現且已確認根因的 autocomplete 問題。

## 驗證
- `corepack pnpm test`
- `corepack pnpm build`